### PR TITLE
[Taskrunner update] Gulp added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 *.swo
 *.db
 node_modules/
+dist/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,38 @@
+'use strict';
+ 
+var gulp = require('gulp');
+var sass = require('gulp-sass');
+var watch = require('gulp-watch');
+var concat = require('gulp-concat');
+var uglify = require('gulp-uglifyjs');
+
+const paths = {
+    sass: './assets/sass/**/*.scss',
+    js: './assets/js/**/**/*.js'
+}
+
+const dest = {
+    css: './dist/css/',
+    js: './dist/js/'
+}
+
+gulp.task('sass', function() {
+    return gulp.src(paths.sass)
+        .pipe(sass().on('error', sass.logError))
+        .pipe(concat('src.css'))
+        .pipe(gulp.dest(dest.css));
+});
+
+gulp.task('js-concat', function() {
+  return gulp.src(paths.js)
+    .pipe(concat('src.js'))
+    .pipe(uglify())
+    .pipe(gulp.dest('./dist/js/'));
+});
+
+gulp.task('watch', function(){
+    gulp.watch(paths.sass, ['sass']);
+    gulp.watch(paths.js, ['js-concat']);
+});
+
+gulp.task('default', ['sass','js-concat','watch']);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Group project for ITCS 4155 at UNCC",
   "main": "app.js",
   "scripts": {
+    "start": "gulp default && npm app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -22,6 +23,13 @@
     "ejs": "^2.5.7",
     "express": "^4.16.2",
     "express-fileupload": "^0.4.0",
+    "gulp": "^3.9.1",
     "multer": "^1.3.0"
+  },
+  "devDependencies": {
+    "gulp-concat": "^2.6.1",
+    "gulp-sass": "^3.1.0",
+    "gulp-uglifyjs": "^0.6.2",
+    "gulp-watch": "^5.0.0"
   }
 }


### PR DESCRIPTION
Gulp is a taskrunner for compile time and run time compilation, concatenation, uglification, etc. I've set up gulp for a myriad of purposes, though we can always add more as we go. **Be sure to run ** `npm install` ** to get all the necessary dependencies.**

**Tasks defined:**

- `sass`

    - Compiles SASS (.scss) files in the `/assets/sass` directory (including subdirectories) into a single .css file

    - Concatenates the output of the compilation to a single .css file in `/dist/css`

- `js-concat`

    - Concatenates JS (.js) files in the `/assets/js` directory (including subdirectories) into a single .js file

    - Uglifies the output of the compilation to a single .css file in `/dist/js`

- `watch`

    - Watches for changes in `/assets/sass` (including subdirectories) and reruns `sass` on change

    - Watches for changes in `/assets/js` (including subdirectories) and reruns `js-concat` on change

- `default`

    - runs `sass`, `js-concat`, and `watch` at startup

**Important notes:** 

- You can start the server now with `npm run start`, this will run gulp default && npm app.js

- Gulp's `watch` functionality does **not** work for new files, only files existing at time of gulp script run. 

- Currently there's no `/assets/` or `/dist/` directories as I haven't started creating anything. Make sure to set up the following directories: 

    - `/assets/js/`
    - `/assets/sass/`
    - `/dist/css/`
    - `/dist/js/`